### PR TITLE
Use same graph instance app-wide

### DIFF
--- a/flask_bulbs.py
+++ b/flask_bulbs.py
@@ -6,14 +6,6 @@ import importlib
 
 from flask import current_app
 
-# Find the stack on which we want to store the database connection.
-# Starting with Flask 0.9, the _app_ctx_stack is the correct one,
-# before that we need to use the _request_ctx_stack.
-try:
-    from flask import _app_ctx_stack as stack
-except ImportError:
-    from flask import _request_ctx_stack as stack
-
 
 class Bulbs(object):
 
@@ -26,44 +18,37 @@ class Bulbs(object):
             self.init_app(app)
 
     def init_app(self, app):
-        app.config.setdefault('BULBS_DATABASE', 'rexster')
-        app.config.setdefault('BULBS_URI', 'http://localhost:8182/graphs/emptygraph')
-        app.config.setdefault('BULBS_USER', None)
-        app.config.setdefault('BULBS_PASSWORD', None)
-        app.config.setdefault('BULBS_LOG_LEVEL', 'INFO')
-        # Use the newstyle teardown_appcontext if it's available,
-        # otherwise fall back to the request context
-        if hasattr(app, 'teardown_appcontext'):
-            app.teardown_appcontext(self.teardown)
-        else:
-            app.teardown_request(self.teardown)
+        config = app.config.copy()
 
-    def get_graph(self):
+        config.setdefault('BULBS_DATABASE', 'rexster')
+        config.setdefault('BULBS_URI', 'http://localhost:8182/graphs/emptygraph')
+        config.setdefault('BULBS_USER', None)
+        config.setdefault('BULBS_PASSWORD', None)
+        config.setdefault('BULBS_LOG_LEVEL', 'INFO')
+
+        app.extensions.setdefault('bulbs', {})
+        app.extensions['bulbs'][self] = self._get_graph(config)
+
+    def _get_graph(self, config):
         """Get bulbs Graph based an app settings."""
-        assert current_app.config['BULBS_DATABASE'] in self.db_types, "Valid values for 'BULBS_DATABASE' are: %r" % self.db_types
-        assert current_app.config['BULBS_LOG_LEVEL'] in self.log_levels, "Valid values for 'BULBS_LOG_LEVEL' are: %r" % self.log_levels
+        assert config['BULBS_DATABASE'] in self.db_types, \
+            "Valid values for 'BULBS_DATABASE' are: %r" % self.db_types
+        assert config['BULBS_LOG_LEVEL'] in self.log_levels, \
+            "Valid values for 'BULBS_LOG_LEVEL' are: %r" % self.log_levels
 
-        db = importlib.import_module('.%s' % current_app.config['BULBS_DATABASE'], 'bulbs')
-        log_level = getattr(bulbs.config, current_app.config['BULBS_LOG_LEVEL'])
+        db = importlib.import_module('.%s' % config['BULBS_DATABASE'], 'bulbs')
+        log_level = getattr(bulbs.config, config['BULBS_LOG_LEVEL'])
 
-        config = db.Config(
-            current_app.config['BULBS_URI'],
-            username=current_app.config['BULBS_USER'],
-            password=current_app.config['BULBS_PASSWORD'],
+        bulbs_config = db.Config(
+            config['BULBS_URI'],
+            username=config['BULBS_USER'],
+            password=config['BULBS_PASSWORD'],
         )
-        config.set_logger(log_level)
+        bulbs_config.set_logger(log_level)
 
-        return db.Graph(config)
-
-    def teardown(self, exception):
-        ctx = stack.top
-        if hasattr(ctx, 'graph'):
-            ctx.graph = None
+        return db.Graph(bulbs_config)
 
     @property
     def graph(self):
-        ctx = stack.top
-        if ctx is not None:
-            if not hasattr(ctx, 'graph'):
-                ctx.graph = self.get_graph()
-            return ctx.graph
+        app = self.app or current_app
+        return app.extensions['bulbs'][self]

--- a/flask_bulbs.py
+++ b/flask_bulbs.py
@@ -25,6 +25,7 @@ class Bulbs(object):
         config.setdefault('BULBS_USER', None)
         config.setdefault('BULBS_PASSWORD', None)
         config.setdefault('BULBS_LOG_LEVEL', 'INFO')
+        config.setdefault('BULBS_CONFIG', {})
 
         app.extensions.setdefault('bulbs', {})
         app.extensions['bulbs'][self] = self._get_graph(config)
@@ -42,9 +43,12 @@ class Bulbs(object):
         bulbs_config = db.Config(
             config['BULBS_URI'],
             username=config['BULBS_USER'],
-            password=config['BULBS_PASSWORD'],
+            password=config['BULBS_PASSWORD']
         )
         bulbs_config.set_logger(log_level)
+
+        for key, value in config['BULBS_CONFIG'].iteritems():
+            setattr(bulbs_config, key, value)
 
         return db.Graph(bulbs_config)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup
 
 setup(
     name='Flask-Bulbs',
-    version='0.1',
+    version='0.2',
     url='http://github.com/peterhil/flask-bulbs/',
     license='MIT',
     author='Peter Hillerström',


### PR DESCRIPTION
With inspiration from [Flask-Cache](https://github.com/thadeusb/flask-cache/blob/4b2feebbcb53aa4021a4f86550aa5ae714763f69/flask_cache/__init__.py#L185-L192).

I was having a bit of trouble with my proxy initializations: I would create an app context during my app initialization phase, so I could get `my_bulbs.graph`, but when execution reached my views, the context had changed, including the `Graph`.

With this, state is tied to an app, instead of a context, and multiple apps are still supported.

Cheers
